### PR TITLE
Fetch resources with filter group=kanslia

### DIFF
--- a/app/api/actions/resources.js
+++ b/app/api/actions/resources.js
@@ -19,9 +19,13 @@ function fetchResource(id, params = {}) {
 }
 
 function fetchResources(params = {}) {
+  const defaultParams = {
+    group: 'kanslia',
+    pageSize: 100,
+  };
   return createApiAction({
     endpoint: 'resource',
-    params: { ...getParamsWithTimes(params), pageSize: 100 },
+    params: { ...defaultParams, ...getParamsWithTimes(params) },
     method: 'GET',
     type: 'RESOURCES',
     options: { schema: schemas.paginatedResourcesSchema },

--- a/app/api/actions/resources.spec.js
+++ b/app/api/actions/resources.spec.js
@@ -66,7 +66,7 @@ describe('api/actions/resources', () => {
   });
 
   describe('fetchResources', () => {
-    const params = getParamsWithTimes({ pageSize: 100 });
+    const params = getParamsWithTimes({ group: 'kanslia', pageSize: 100 });
     createApiTest({
       name: 'fetchResources',
       action: fetchResources,


### PR DESCRIPTION
This only fetches the resources that are supposed to show in huvaja.
Closes #57.