### PR TITLE
Remove times from timeline reservations

### DIFF
--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/Reservation.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/Reservation.js
@@ -38,10 +38,6 @@ function Reservation(props) {
       trigger={['hover', 'focus']}
     >
       <div className="reservation" style={{ width }}>
-        <div className="times">
-          <div className="start-time">{startTime.format('HH:mm')}</div>
-          <div className="end-time">{endTime.format('HH:mm')}</div>
-        </div>
         <div className="names">
           <div className="event-subject">{props.eventSubject}</div>
           <div className="reserver-name">{props.reserverName}</div>

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/Reservation.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/Reservation.spec.js
@@ -64,20 +64,6 @@ describe('shared/availability-view/Reservation', () => {
     expect(actual).to.deep.equal({ width: expected });
   });
 
-  it('renders start time', () => {
-    const begin = '2016-01-01T10:30:00Z';
-    const element = getWrapper({ begin }).find('.start-time');
-    expect(element).to.have.length(1);
-    expect(element.text()).to.equal(moment(begin).format('HH:mm'));
-  });
-
-  it('renders end time', () => {
-    const end = '2016-01-01T10:30:00Z';
-    const element = getWrapper({ end }).find('.end-time');
-    expect(element).to.have.length(1);
-    expect(element.text()).to.equal(moment(end).format('HH:mm'));
-  });
-
   it('renders eventSubject', () => {
     const eventSubject = 'Meeting GUQ';
     const element = getWrapper({ eventSubject }).find('.event-subject');

--- a/app/shared/availability-view/availability-view.less
+++ b/app/shared/availability-view/availability-view.less
@@ -133,12 +133,11 @@
     overflow: hidden;
     cursor: pointer;
 
-    .times {
-      margin-right: @padding-small-horizontal;
-    }
     .names {
+      height: 100%;
       overflow: hidden;
-      text-overflow: ellipsis;
+      text-overflow: clip;
+      white-space: nowrap;
     }
   }
   .reservation-slot {


### PR DESCRIPTION
Also makes sure event subject and reserver name are rendered on their
own lines and do not wrap to multiple lines.

Closes #76.